### PR TITLE
fix(#17): tech tree layout — grid for disconnected components + neuroscript-rs

### DIFF
--- a/src/TechTree.jsx
+++ b/src/TechTree.jsx
@@ -11,6 +11,7 @@ const PROJECT_COLORS = {
   'dnd-tools': '#ffc857',
   'meeting-scribe': '#fb923c',
   'wasteland-orchestrator': '#ff5c5c',
+  'neuroscript-rs': '#e879f9',
 }
 
 const PROJECT_COLOR_DIM = Object.fromEntries(
@@ -80,22 +81,41 @@ function getComplexity(issue) {
   return 'medium' // default
 }
 
-function buildGraph(issues) {
-  const g = new dagre.graphlib.Graph()
-  g.setGraph({
-    rankdir: 'TB',
-    ranksep: 80,
-    nodesep: 50,
-    marginx: 40,
-    marginy: 40,
-  })
-  g.setDefaultEdgeLabel(() => ({}))
+// Find connected components in a set of nodes + edges
+function findComponents(nodeKeys, edgeList) {
+  const parent = new Map()
+  for (const key of nodeKeys) parent.set(key, key)
 
+  function find(x) {
+    while (parent.get(x) !== x) {
+      parent.set(x, parent.get(parent.get(x)))
+      x = parent.get(x)
+    }
+    return x
+  }
+  function union(a, b) {
+    parent.set(find(a), find(b))
+  }
+
+  for (const { from, to } of edgeList) {
+    if (parent.has(from) && parent.has(to)) union(from, to)
+  }
+
+  const groups = new Map()
+  for (const key of nodeKeys) {
+    const root = find(key)
+    if (!groups.has(root)) groups.set(root, [])
+    groups.get(root).push(key)
+  }
+  return [...groups.values()]
+}
+
+function buildGraph(issues) {
   const nodeMap = new Map()
   const nodeWidth = 220
   const nodeHeight = 80
 
-  // Add all issues as nodes
+  // Build all node data
   for (const issue of issues) {
     const key = `${issue.repo}#${issue.number}`
     const status = getIssueStatus(issue)
@@ -109,71 +129,149 @@ function buildGraph(issues) {
       color: PROJECT_COLORS[issue.repo] || '#4ea8ff',
       colorDim: PROJECT_COLOR_DIM[issue.repo] || '#4ea8ff30',
     })
-
-    g.setNode(key, { width: nodeWidth, height: nodeHeight })
   }
 
-  // Add edges based on dependencies
-  const edges = []
+  // Collect all edges
+  const allEdges = []
   for (const issue of issues) {
     const deps = extractDependencies(issue)
     const toKey = `${issue.repo}#${issue.number}`
-
     for (const dep of deps) {
       const fromKey = `${dep.repo}#${dep.number}`
       if (nodeMap.has(fromKey)) {
-        g.setEdge(fromKey, toKey)
-        edges.push({ from: fromKey, to: toKey })
+        allEdges.push({ from: fromKey, to: toKey })
       }
     }
   }
 
-  // Also connect issues with "needs-breakdown" to their parent if referenced
-  // and connect issues that share a milestone
+  // Mark needs-breakdown nodes
   for (const issue of issues) {
     const labels = issue.labels.map(l => l.name.toLowerCase())
     if (labels.includes('needs-breakdown') || labels.includes('needs:brainstorm')) {
-      // Mark these as "root" nodes that need work before their dependents
       const key = `${issue.repo}#${issue.number}`
       const node = nodeMap.get(key)
       if (node) node.needsBreakdown = true
     }
   }
 
-  // Run dagre layout
-  dagre.layout(g)
+  // Split into connected components
+  const nodeKeys = [...nodeMap.keys()]
+  const components = findComponents(nodeKeys, allEdges)
 
-  // Extract positioned nodes
-  const nodes = []
-  g.nodes().forEach((key) => {
-    const layoutNode = g.node(key)
-    const data = nodeMap.get(key)
-    if (data && layoutNode) {
-      nodes.push({
-        ...data,
-        x: layoutNode.x,
-        y: layoutNode.y,
-        width: nodeWidth,
-        height: nodeHeight,
-      })
-    }
+  // Sort components: largest first, then by whether they have edges
+  components.sort((a, b) => {
+    const aHasEdges = allEdges.some(e => a.includes(e.from) || a.includes(e.to))
+    const bHasEdges = allEdges.some(e => b.includes(e.from) || b.includes(e.to))
+    if (aHasEdges !== bHasEdges) return bHasEdges ? 1 : -1
+    return b.length - a.length
   })
 
-  // Extract positioned edges with points
-  const positionedEdges = []
-  g.edges().forEach((e) => {
-    const edgeData = g.edge(e)
-    if (edgeData?.points) {
-      positionedEdges.push({
-        from: e.v,
-        to: e.w,
-        points: edgeData.points,
-        fromColor: nodeMap.get(e.v)?.color || '#4ea8ff',
-      })
-    }
-  })
+  // Layout each component separately with dagre, then arrange in a grid
+  const allNodes = []
+  const allPositionedEdges = []
+  const COMPONENT_GAP_X = 60
+  const COMPONENT_GAP_Y = 60
 
-  return { nodes, edges: positionedEdges }
+  // Determine grid columns: ~3 columns for many components, fewer for few
+  const numCols = components.length <= 2 ? components.length
+    : components.length <= 6 ? 3
+    : 4
+
+  let gridX = 0
+  let gridY = 0
+  let colIndex = 0
+  const rowHeights = []
+  let currentRowHeight = 0
+
+  for (const component of components) {
+    // Build a sub-graph for this component
+    const g = new dagre.graphlib.Graph()
+    g.setGraph({
+      rankdir: 'TB',
+      ranksep: 100,
+      nodesep: 40,
+      marginx: 20,
+      marginy: 20,
+    })
+    g.setDefaultEdgeLabel(() => ({}))
+
+    for (const key of component) {
+      g.setNode(key, { width: nodeWidth, height: nodeHeight })
+    }
+
+    // Add edges belonging to this component
+    const compSet = new Set(component)
+    for (const edge of allEdges) {
+      if (compSet.has(edge.from) && compSet.has(edge.to)) {
+        g.setEdge(edge.from, edge.to)
+      }
+    }
+
+    dagre.layout(g)
+
+    // Find bounding box of this component layout
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    g.nodes().forEach((key) => {
+      const n = g.node(key)
+      if (n) {
+        minX = Math.min(minX, n.x - nodeWidth / 2)
+        minY = Math.min(minY, n.y - nodeHeight / 2)
+        maxX = Math.max(maxX, n.x + nodeWidth / 2)
+        maxY = Math.max(maxY, n.y + nodeHeight / 2)
+      }
+    })
+
+    const compWidth = maxX - minX
+    const compHeight = maxY - minY
+
+    // Offset nodes to grid position
+    const offsetX = gridX - minX
+    const offsetY = gridY - minY
+
+    g.nodes().forEach((key) => {
+      const layoutNode = g.node(key)
+      const data = nodeMap.get(key)
+      if (data && layoutNode) {
+        allNodes.push({
+          ...data,
+          x: layoutNode.x + offsetX,
+          y: layoutNode.y + offsetY,
+          width: nodeWidth,
+          height: nodeHeight,
+        })
+      }
+    })
+
+    // Offset edges
+    g.edges().forEach((e) => {
+      const edgeData = g.edge(e)
+      if (edgeData?.points) {
+        allPositionedEdges.push({
+          from: e.v,
+          to: e.w,
+          points: edgeData.points.map(p => ({ x: p.x + offsetX, y: p.y + offsetY })),
+          fromColor: nodeMap.get(e.v)?.color || '#4ea8ff',
+        })
+      }
+    })
+
+    // Advance grid position
+    currentRowHeight = Math.max(currentRowHeight, compHeight)
+    colIndex++
+
+    if (colIndex >= numCols) {
+      // Next row
+      gridX = 0
+      gridY += currentRowHeight + COMPONENT_GAP_Y
+      colIndex = 0
+      rowHeights.push(currentRowHeight)
+      currentRowHeight = 0
+    } else {
+      gridX += compWidth + COMPONENT_GAP_X
+    }
+  }
+
+  return { nodes: allNodes, edges: allPositionedEdges }
 }
 
 // ── SVG Components ──────────────────────────

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,6 +10,7 @@ const PINBOARD_PATH = path.join(process.env.HOME, '.claude', 'pinboard.json')
 
 const GITEA_URL = 'http://localhost:3003'
 const GITEA_ORG = 'tquick'
+// Each entry is either 'repo' (uses GITEA_ORG) or 'org/repo' (explicit org)
 const REPOS = [
   'dungeon-crawler',
   'wasteland-infra',
@@ -18,7 +19,16 @@ const REPOS = [
   'dnd-tools',
   'meeting-scribe',
   'wasteland-orchestrator',
+  'severeon/neuroscript-rs',
 ]
+
+function repoFullPath(entry) {
+  return entry.includes('/') ? entry : `${GITEA_ORG}/${entry}`
+}
+
+function repoName(entry) {
+  return entry.includes('/') ? entry.split('/').pop() : entry
+}
 
 function getGiteaToken() {
   try {
@@ -157,9 +167,11 @@ function giteaIssuesPlugin() {
 
         try {
           const allIssues = []
-          for (const repo of REPOS) {
+          for (const entry of REPOS) {
             try {
-              const url = `${GITEA_URL}/api/v1/repos/${GITEA_ORG}/${repo}/issues?state=open&type=issues&limit=50`
+              const fullPath = repoFullPath(entry)
+              const name = repoName(entry)
+              const url = `${GITEA_URL}/api/v1/repos/${fullPath}/issues?state=open&type=issues&limit=50`
               const response = await fetch(url, { headers })
               if (response.ok) {
                 const issues = await response.json()
@@ -170,8 +182,8 @@ function giteaIssuesPlugin() {
                     title: issue.title,
                     body: issue.body || '',
                     state: issue.state,
-                    repo: repo,
-                    url: `${GITEA_URL}/${GITEA_ORG}/${repo}/issues/${issue.number}`,
+                    repo: name,
+                    url: `${GITEA_URL}/${fullPath}/issues/${issue.number}`,
                     labels: (issue.labels || []).map((l) => ({
                       name: l.name,
                       color: l.color,


### PR DESCRIPTION
## Summary
- **Tech tree layout fix**: Each connected component is now laid out separately with dagre, then components are arranged in a grid (up to 4 columns). Previously all nodes landed on the same rank, creating a flat horizontal line.
- **neuroscript-rs added**: `severeon/neuroscript-rs` added to Vite issues proxy (with multi-org support), TechTree project colors, and hq-status-writer.

Fixes #17

## Test plan
- [ ] Open Tech Tree tab — nodes should be arranged in tree/grid layout, not a flat line
- [ ] Dependency edges should flow top-to-bottom within connected components
- [ ] Disconnected components should be arranged in columns
- [ ] neuroscript-rs issues should appear in the tech tree with fuchsia color
- [ ] neuroscript-rs should appear in the dashboard projects section
- [ ] Filter chips should include neuroscript-rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)