### PR TITLE
refactor(#16): DRY stale item visibility

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -254,6 +254,81 @@
   opacity: 0.7;
 }
 
+/* ── Pinboard ──────────────────────────── */
+.pinboard-section {
+  margin-bottom: 40px;
+  animation: slide-up 0.5s ease-out 0.15s both;
+}
+
+.pin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 10px;
+}
+
+.pin-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 12px 14px;
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.pin-card:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--border-accent);
+}
+
+.pin-card.done {
+  opacity: 0.45;
+  border-style: dashed;
+}
+
+.pin-card.urgent {
+  border-left: 3px solid var(--red);
+}
+
+.pin-text {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+.pin-card.done .pin-text {
+  text-decoration: line-through;
+  color: var(--text-dim);
+}
+
+.pin-project {
+  font-size: 0.65rem;
+  color: var(--cyan);
+  margin-top: 6px;
+  opacity: 0.7;
+}
+
+.pin-tags {
+  display: flex;
+  gap: 4px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.pin-tag {
+  font-size: 0.6rem;
+  color: var(--text-dim);
+  padding: 1px 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 3px;
+}
+
+.pin-empty {
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  font-style: italic;
+  padding: 12px;
+}
+
 /* ── Projects ───────────────────────────── */
 .projects-section {
   margin-bottom: 40px;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import './App.css'
 import TechTree from './TechTree.jsx'
+import VisibilityToggle from './VisibilityToggle.jsx'
+import { useVisibilityToggle, isAgentStale, isPinDone } from './useVisibilityToggle.js'
 
 const STATE_COLORS = {
   working: 'var(--green)',
@@ -109,7 +111,7 @@ function ProjectRow({ project, maxIssues }) {
 function SummaryBar({ agents, projects }) {
   const working = agents?.filter(a => a.state === 'working' && a.alive).length || 0
   const idle = agents?.filter(a => a.state === 'idle').length || 0
-  const stale = agents?.filter(a => a.stale && !a.alive).length || 0
+  const stale = agents?.filter(isAgentStale).length || 0
   const totalIssues = projects?.reduce((s, p) => s + p.open, 0) || 0
   const totalSprint = projects?.reduce((s, p) => s + p.sprint, 0) || 0
 
@@ -169,8 +171,19 @@ export default function App() {
 
   const agents = data?.agents || []
   const projects = data?.projects || []
+  const pinboard = data?.pinboard || []
   const lead = getLeadAgent(agents)
   const maxIssues = Math.max(...projects.map(p => p.open), 1)
+
+  // Shared visibility toggles using the DRY hook
+  const agentVis = useVisibilityToggle('hq-show-all-agents', {
+    items: agents,
+    isHidden: isAgentStale,
+  })
+  const pinVis = useVisibilityToggle('hq-show-done-pins', {
+    items: pinboard,
+    isHidden: isPinDone,
+  })
 
   const timeStr = clock.toLocaleTimeString('en-US', {
     hour: '2-digit',
@@ -217,13 +230,51 @@ export default function App() {
         <>
           {/* ── Agents ── */}
           <div className="agents-section">
-            <div className="section-label">Agents</div>
+            <div className="section-label">
+              Agents
+              <VisibilityToggle
+                showAll={agentVis.showAll}
+                hiddenCount={agentVis.hiddenCount}
+                onToggle={agentVis.toggle}
+                hideLabel={`Hide stale (${agentVis.hiddenCount})`}
+                showLabel={`Show all (${agents.length})`}
+              />
+            </div>
             <div className="agent-grid">
-              {agents.map(a => (
+              {agentVis.visible.map(a => (
                 <AgentCard key={a.agent} agent={a} />
               ))}
             </div>
           </div>
+
+          {/* ── Pinboard ── */}
+          {pinboard.length > 0 && (
+            <div className="pinboard-section">
+              <div className="section-label">
+                Pinboard
+                <VisibilityToggle
+                  showAll={pinVis.showAll}
+                  hiddenCount={pinVis.hiddenCount}
+                  onToggle={pinVis.toggle}
+                  hideLabel={`Hide done (${pinVis.hiddenCount})`}
+                  showLabel={`Show all (+${pinVis.hiddenCount} done)`}
+                />
+              </div>
+              <div className="pin-grid">
+                {pinVis.visible.map(note => (
+                  <div key={note.id} className={`pin-card ${note.done ? 'done' : ''} ${note.priority === 'urgent' ? 'urgent' : ''}`}>
+                    <div className="pin-text">{note.text}</div>
+                    {note.project && <div className="pin-project">{note.project}</div>}
+                    {note.tags?.length > 0 && (
+                      <div className="pin-tags">
+                        {note.tags.map(t => <span key={t} className="pin-tag">{t}</span>)}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           {/* ── Projects ── */}
           <div className="projects-section">

--- a/src/VisibilityToggle.css
+++ b/src/VisibilityToggle.css
@@ -1,0 +1,23 @@
+/* ── Shared visibility toggle ─────────────── */
+/* Reusable toggle for hiding stale/done items across sections */
+
+.visibility-toggle {
+  float: right;
+  background: none;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  color: var(--text-dim);
+  font-size: 0.65rem;
+  font-family: var(--font-body);
+  padding: 3px 8px;
+  cursor: pointer;
+  text-transform: none;
+  font-weight: 400;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+
+.visibility-toggle:hover {
+  background: var(--bg-card-hover);
+  color: var(--text-secondary);
+  border-color: var(--border-accent);
+}

--- a/src/VisibilityToggle.jsx
+++ b/src/VisibilityToggle.jsx
@@ -1,0 +1,16 @@
+import './VisibilityToggle.css'
+
+// ── Shared visibility toggle button ──────────
+// Used by any section that hides stale/done items
+export default function VisibilityToggle({ showAll, hiddenCount, onToggle, showLabel, hideLabel }) {
+  if (hiddenCount === 0) return null
+
+  return (
+    <button className="visibility-toggle" onClick={onToggle}>
+      {showAll
+        ? (hideLabel || `Hide ${hiddenCount}`)
+        : (showLabel || `Show all (+${hiddenCount})`)
+      }
+    </button>
+  )
+}

--- a/src/useVisibilityToggle.js
+++ b/src/useVisibilityToggle.js
@@ -1,0 +1,46 @@
+import { useState, useCallback } from 'react'
+
+// ── Shared stale/visibility constants ────────
+export const STALE_THRESHOLD_SEC = 30 * 60 // 30 minutes
+
+// ── Reusable visibility toggle hook ──────────
+// storageKey: localStorage key for persisting toggle state
+// Returns: { showAll, toggle, hiddenCount }
+export function useVisibilityToggle(storageKey, { items = [], isHidden }) {
+  const [showAll, setShowAll] = useState(() => {
+    try {
+      return localStorage.getItem(storageKey) === 'true'
+    } catch {
+      return false
+    }
+  })
+
+  const toggle = useCallback(() => {
+    setShowAll(prev => {
+      const next = !prev
+      try { localStorage.setItem(storageKey, String(next)) } catch {}
+      return next
+    })
+  }, [storageKey])
+
+  const visible = showAll ? items : items.filter(item => !isHidden(item))
+  const hiddenCount = items.length - items.filter(item => !isHidden(item)).length
+
+  return { showAll, toggle, visible, hiddenCount }
+}
+
+// ── Agent staleness check ────────────────────
+export function isAgentStale(agent) {
+  if (agent.alive) return false
+  if (!agent.stale) return false
+  // Working/reviewing/brainstorming agents are never "stale" for display
+  if (['working', 'reviewing', 'brainstorming'].includes(agent.state)) return false
+  // Recent heartbeat within threshold
+  if (agent.age_sec != null && agent.age_sec < STALE_THRESHOLD_SEC) return false
+  return true
+}
+
+// ── Pinboard done check ──────────────────────
+export function isPinDone(note) {
+  return !!note.done
+}


### PR DESCRIPTION
## Summary
- Extract `useVisibilityToggle` hook — reusable toggle with localStorage persistence and configurable `isHidden` predicate
- Extract `VisibilityToggle` component — shared button with consistent styling
- Extract shared constants: `STALE_THRESHOLD_SEC`, `isAgentStale()`, `isPinDone()`
- Apply to agents section: stale agents hidden by default with toggle
- Add pinboard section with done-item hiding using same pattern
- SummaryBar uses shared `isAgentStale()` instead of inline filter

Future sections can reuse by calling `useVisibilityToggle(storageKey, { items, isHidden })`.

## Test plan
- [ ] Verify agents section shows toggle when stale agents exist
- [ ] Toggle persists across page reloads (localStorage)
- [ ] Pinboard shows with done-item toggle when done pins exist
- [ ] Build passes (`npm run build`)

Closes tquick/wasteland-hq#16 (Gitea)

🤖 Generated with [Claude Code](https://claude.com/claude-code)