### PR TITLE
refactor(#18): single source of truth for tracked repos

### DIFF
--- a/src/TechTree.jsx
+++ b/src/TechTree.jsx
@@ -1,22 +1,11 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
 import dagre from '@dagrejs/dagre'
+import { REPO_COLORS, REPO_COLORS_DIM } from './config/repos.js'
 import './TechTree.css'
 
-// ── Project colors ──────────────────────────
-const PROJECT_COLORS = {
-  'dungeon-crawler': '#00e88f',
-  'wasteland-infra': '#4ea8ff',
-  'claude-gate': '#a78bfa',
-  'wasteland-hq': '#22d3ee',
-  'dnd-tools': '#ffc857',
-  'meeting-scribe': '#fb923c',
-  'wasteland-orchestrator': '#ff5c5c',
-  'neuroscript-rs': '#e879f9',
-}
-
-const PROJECT_COLOR_DIM = Object.fromEntries(
-  Object.entries(PROJECT_COLORS).map(([k, v]) => [k, v + '30'])
-)
+// ── Project colors (from centralized config) ─
+const PROJECT_COLORS = REPO_COLORS
+const PROJECT_COLOR_DIM = REPO_COLORS_DIM
 
 // ── Complexity shapes ───────────────────────
 // trivial = small circle, small = circle, medium = rounded rect, large = rect, epic = diamond

--- a/src/config/repos.js
+++ b/src/config/repos.js
@@ -1,0 +1,39 @@
+/**
+ * Single source of truth for all tracked repositories.
+ *
+ * Every component that needs the repo list, colors, or org info
+ * should import from here instead of maintaining its own copy.
+ *
+ * To add a new repo: add an entry to REPOS below. That's it.
+ */
+
+export const GITEA_URL = 'http://localhost:3003'
+export const GITEA_ORG = 'tquick'
+
+/**
+ * Tracked repositories with display metadata.
+ * @type {Array<{ name: string, color: string }>}
+ */
+export const REPOS = [
+  { name: 'dungeon-crawler',        color: '#00e88f' },
+  { name: 'wasteland-infra',        color: '#4ea8ff' },
+  { name: 'claude-gate',            color: '#a78bfa' },
+  { name: 'wasteland-hq',           color: '#22d3ee' },
+  { name: 'dnd-tools',              color: '#ffc857' },
+  { name: 'meeting-scribe',         color: '#fb923c' },
+  { name: 'wasteland-orchestrator', color: '#ff5c5c' },
+  { name: 'neuroscript-rs',         color: '#e879f9' },
+]
+
+/** Repo names as a flat array (for iteration in API calls, etc.) */
+export const REPO_NAMES = REPOS.map(r => r.name)
+
+/** Map of repo name → display color */
+export const REPO_COLORS = Object.fromEntries(
+  REPOS.map(r => [r.name, r.color])
+)
+
+/** Map of repo name → dimmed color (for backgrounds) */
+export const REPO_COLORS_DIM = Object.fromEntries(
+  REPOS.map(r => [r.name, r.color + '30'])
+)

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,18 +2,7 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { readFileSync } from 'fs'
 import { join } from 'path'
-
-const GITEA_URL = 'http://localhost:3003'
-const GITEA_ORG = 'tquick'
-const REPOS = [
-  'dungeon-crawler',
-  'wasteland-infra',
-  'claude-gate',
-  'wasteland-hq',
-  'dnd-tools',
-  'meeting-scribe',
-  'wasteland-orchestrator',
-]
+import { GITEA_URL, GITEA_ORG, REPO_NAMES } from './src/config/repos.js'
 
 function getGiteaToken() {
   try {
@@ -38,7 +27,7 @@ function giteaIssuesPlugin() {
 
         try {
           const allIssues = []
-          for (const repo of REPOS) {
+          for (const repo of REPO_NAMES) {
             try {
               const url = `${GITEA_URL}/api/v1/repos/${GITEA_ORG}/${repo}/issues?state=open&type=issues&limit=50`
               const response = await fetch(url, { headers })


### PR DESCRIPTION
## Summary
- Created `src/config/repos.js` as the single source of truth for all tracked repositories
- `vite.config.js` now imports `GITEA_URL`, `GITEA_ORG`, and `REPO_NAMES` from the centralized config
- `TechTree.jsx` now imports `REPO_COLORS` and `REPO_COLORS_DIM` from the centralized config
- Adding a new repo now requires editing only one file instead of 2-3
- Fixed: `neuroscript-rs` was missing from vite.config's REPOS array but present in TechTree — now consistent everywhere

Closes tquick/wasteland-hq#18 (Gitea)

## Test plan
- [ ] `npx vite build` passes (verified ✅)
- [ ] Dashboard loads and shows all repos including neuroscript-rs
- [ ] Tech tree colors match previous behavior
- [ ] Issue fetching works for all 8 repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)