### PR TITLE
feat(#14): expand story bar with issue counters

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -411,12 +411,26 @@
 /* ── Summary Bar ────────────────────────── */
 .summary-bar {
   display: flex;
-  gap: 32px;
+  flex-wrap: wrap;
+  gap: 12px 32px;
   padding: 16px 0;
   border-top: 1px solid var(--border-subtle);
   font-size: 0.78rem;
   color: var(--text-dim);
   animation: fade-in 0.6s ease-out 0.3s both;
+}
+
+.summary-group {
+  display: flex;
+  gap: 20px;
+  align-items: center;
+}
+
+.summary-divider {
+  width: 1px;
+  height: 16px;
+  background: var(--border-subtle);
+  align-self: center;
 }
 
 .summary-stat {
@@ -433,6 +447,7 @@
 
 .summary-stat .dot.green { background: var(--green); }
 .summary-stat .dot.blue { background: var(--blue); }
+.summary-stat .dot.cyan { background: var(--cyan, #22d3ee); }
 .summary-stat .dot.yellow { background: var(--yellow); }
 .summary-stat .dot.red { background: var(--red); }
 .summary-stat .dot.dim { background: var(--text-dim); }
@@ -440,6 +455,12 @@
 .summary-stat .value {
   font-weight: 600;
   color: var(--text-secondary);
+}
+
+.summary-stat .stat-detail {
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  opacity: 0.7;
 }
 
 /* ── Pulse indicator (top-right) ────────── */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,26 @@ function useStatus(interval = 3000) {
   return { data, error }
 }
 
+function useIssueStats(interval = 30000) {
+  const [stats, setStats] = useState(null)
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const res = await fetch('/api/issue-stats?' + Date.now())
+        if (res.ok) setStats(await res.json())
+      } catch {
+        // Silently fail — summary bar shows fallback
+      }
+    }
+    fetchStats()
+    const id = setInterval(fetchStats, interval)
+    return () => clearInterval(id)
+  }, [interval])
+
+  return stats
+}
+
 function useClock() {
   const [time, setTime] = useState(new Date())
   useEffect(() => {
@@ -108,36 +128,54 @@ function ProjectRow({ project, maxIssues }) {
   )
 }
 
-function SummaryBar({ agents, projects }) {
+function SummaryBar({ agents, issueStats }) {
   const working = agents?.filter(a => a.state === 'working' && a.alive).length || 0
   const idle = agents?.filter(a => a.state === 'idle').length || 0
   const stale = agents?.filter(isAgentStale).length || 0
-  const totalIssues = projects?.reduce((s, p) => s + p.open, 0) || 0
-  const totalSprint = projects?.reduce((s, p) => s + p.sprint, 0) || 0
 
   return (
     <div className="summary-bar">
-      <div className="summary-stat">
-        <div className="dot green" />
-        <span className="value">{working}</span> working
-      </div>
-      <div className="summary-stat">
-        <div className="dot dim" />
-        <span className="value">{idle}</span> idle
-      </div>
-      {stale > 0 && (
+      {/* Agent stats */}
+      <div className="summary-group">
         <div className="summary-stat">
-          <div className="dot red" />
-          <span className="value">{stale}</span> stale
+          <div className="dot green" />
+          <span className="value">{working}</span> working
         </div>
-      )}
-      <div className="summary-stat">
-        <div className="dot blue" />
-        <span className="value">{totalIssues}</span> issues
+        <div className="summary-stat">
+          <div className="dot dim" />
+          <span className="value">{idle}</span> idle
+        </div>
+        {stale > 0 && (
+          <div className="summary-stat">
+            <div className="dot red" />
+            <span className="value">{stale}</span> stale
+          </div>
+        )}
       </div>
-      <div className="summary-stat">
-        <div className="dot green" />
-        <span className="value">{totalSprint}</span> in sprint
+
+      {/* Separator */}
+      <div className="summary-divider" />
+
+      {/* Issue stats */}
+      <div className="summary-group">
+        <div className="summary-stat">
+          <div className="dot blue" />
+          <span className="value">{issueStats?.open ?? '–'}</span> open
+        </div>
+        <div className="summary-stat">
+          <div className="dot cyan" />
+          <span className="value">{issueStats?.inProgress ?? '–'}</span> in progress
+        </div>
+        {(issueStats?.stalled ?? 0) > 0 && (
+          <div className="summary-stat">
+            <div className="dot yellow" />
+            <span className="value">{issueStats.stalled}</span> stalled
+          </div>
+        )}
+        <div className="summary-stat">
+          <div className="dot green" />
+          <span className="value">{issueStats?.recentlyClosed ?? '–'}</span> closed <span className="stat-detail">48h</span>
+        </div>
       </div>
     </div>
   )
@@ -166,6 +204,7 @@ function TabBar({ activeTab, onTabChange }) {
 
 export default function App() {
   const { data, error } = useStatus(3000)
+  const issueStats = useIssueStats(30000)
   const clock = useClock()
   const [activeTab, setActiveTab] = useState('dashboard')
 
@@ -287,7 +326,7 @@ export default function App() {
           </div>
 
           {/* ── Summary ── */}
-          <SummaryBar agents={agents} projects={projects} />
+          <SummaryBar agents={agents} issueStats={issueStats} />
         </>
       )}
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -81,7 +81,93 @@ function giteaIssuesPlugin() {
   }
 }
 
+function issueStatsPlugin() {
+  return {
+    name: 'issue-stats-proxy',
+    configureServer(server) {
+      server.middlewares.use('/api/issue-stats', async (req, res) => {
+        const token = getGiteaToken()
+        const headers = {
+          'Content-Type': 'application/json',
+          ...(token ? { 'Authorization': `token ${token}` } : {}),
+        }
+
+        try {
+          const openIssues = []
+          const closedIssues = []
+          const STALE_DAYS = 7
+          const RECENTLY_CLOSED_HOURS = 48
+          const now = Date.now()
+
+          for (const repo of REPOS) {
+            try {
+              // Fetch open issues
+              const openUrl = `${GITEA_URL}/api/v1/repos/${GITEA_ORG}/${repo}/issues?state=open&type=issues&limit=50`
+              const openRes = await fetch(openUrl, { headers })
+              if (openRes.ok) {
+                const issues = await openRes.json()
+                openIssues.push(...issues.map(i => ({ ...i, repo })))
+              }
+
+              // Fetch recently closed issues (sorted by updated_at desc)
+              const closedUrl = `${GITEA_URL}/api/v1/repos/${GITEA_ORG}/${repo}/issues?state=closed&type=issues&limit=20&sort=updated&direction=desc`
+              const closedRes = await fetch(closedUrl, { headers })
+              if (closedRes.ok) {
+                const issues = await closedRes.json()
+                closedIssues.push(...issues.map(i => ({ ...i, repo })))
+              }
+            } catch {
+              // Skip repos that fail
+            }
+          }
+
+          // Compute stats
+          const totalOpen = openIssues.length
+
+          // In-progress: has tier:now, in-progress label, or sprint-related label
+          const inProgress = openIssues.filter(i => {
+            const labels = (i.labels || []).map(l => l.name.toLowerCase())
+            return labels.includes('in-progress') ||
+                   labels.includes('tier:now') ||
+                   labels.some(l => l.includes('sprint'))
+          }).length
+
+          // Stalled: in-progress/tier:now but no update in STALE_DAYS
+          const staleThreshold = now - (STALE_DAYS * 24 * 60 * 60 * 1000)
+          const stalled = openIssues.filter(i => {
+            const labels = (i.labels || []).map(l => l.name.toLowerCase())
+            const isActive = labels.includes('in-progress') ||
+                             labels.includes('tier:now') ||
+                             labels.some(l => l.includes('sprint'))
+            const lastUpdate = new Date(i.updated_at).getTime()
+            return isActive && lastUpdate < staleThreshold
+          }).length
+
+          // Recently closed: closed within RECENTLY_CLOSED_HOURS
+          const closedThreshold = now - (RECENTLY_CLOSED_HOURS * 60 * 60 * 1000)
+          const recentlyClosed = closedIssues.filter(i => {
+            const closedAt = new Date(i.closed_at || i.updated_at).getTime()
+            return closedAt >= closedThreshold
+          }).length
+
+          res.writeHead(200, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({
+            open: totalOpen,
+            inProgress,
+            stalled,
+            recentlyClosed,
+            timestamp: new Date().toISOString(),
+          }))
+        } catch (err) {
+          res.writeHead(500, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: err.message }))
+        }
+      })
+    },
+  }
+}
+
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), giteaIssuesPlugin()],
+  plugins: [react(), giteaIssuesPlugin(), issueStatsPlugin()],
 })


### PR DESCRIPTION
## Summary
- Added `/api/issue-stats` Vite plugin endpoint that fetches open + recently closed issues from Gitea and computes derived metrics
- Expanded `SummaryBar` to show: **open** (blue), **in-progress** (cyan), **stalled** (yellow, conditional), **recently closed 48h** (green)
- Added `useIssueStats` hook polling every 30s (separate from the 3s status.json cycle)
- Visual: agent stats and issue stats separated by a divider for clearer grouping

### Issue detection logic
- **In-progress**: has `tier:now`, `in-progress`, or any sprint-related label
- **Stalled**: in-progress but `updated_at` older than 7 days
- **Recently closed**: `closed_at` within the last 48 hours

Closes tquick/wasteland-hq#14 (Gitea)

## Test plan
- [ ] `npx vite build` passes (verified ✅)
- [ ] Dashboard summary bar shows open, in-progress, recently closed counters
- [ ] Stalled counter only appears when > 0
- [ ] Stats refresh every 30 seconds
- [ ] Graceful fallback (shows `–`) when API is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)