### PR TITLE
feat(#24): migrate from Gitea to GitHub API

### DIFF
--- a/src/TechTree.jsx
+++ b/src/TechTree.jsx
@@ -496,7 +496,7 @@ function DetailPanel({ node, onClose }) {
         rel="noopener noreferrer"
         className="detail-link"
       >
-        Open in Gitea →
+        Open in GitHub →
       </a>
     </div>
   )
@@ -608,7 +608,7 @@ export default function TechTree() {
       <div className="tech-tree-container">
         <div className="tech-loading">
           <div className="loading-spinner" />
-          <span>Scanning Gitea for issues…</span>
+          <span>Scanning GitHub for issues…</span>
         </div>
       </div>
     )
@@ -619,9 +619,9 @@ export default function TechTree() {
       <div className="tech-tree-container">
         <div className="tech-error">
           <span className="error-icon">⚠</span>
-          <span>Connection to Gitea failed: {error}</span>
+          <span>Connection to GitHub failed: {error}</span>
           <div className="error-hint">
-            Ensure Gitea is running at localhost:3003
+            Check your GitHub token and network connection
           </div>
         </div>
       </div>

--- a/src/config/repos.js
+++ b/src/config/repos.js
@@ -7,8 +7,8 @@
  * To add a new repo: add an entry to REPOS below. That's it.
  */
 
-export const GITEA_URL = 'http://localhost:3003'
-export const GITEA_ORG = 'tquick'
+export const GITHUB_URL = 'https://api.github.com'
+export const GITHUB_ORG = 'severeon'
 
 /**
  * Tracked repositories with display metadata.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,67 +1,66 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { readFileSync } from 'fs'
-import fs from 'fs'
-import path from 'path'
-import { join } from 'path'
 import fs from 'fs'
 import path from 'path'
 import { execSync } from 'child_process'
-import { GITEA_URL, GITEA_ORG, REPO_NAMES } from './src/config/repos.js'
+import { GITHUB_URL, GITHUB_ORG, REPO_NAMES } from './src/config/repos.js'
 
 const STATUS_PATH = path.join(process.env.HOME, '.claude', 'hq-status.json')
 const PINBOARD_PATH = path.join(process.env.HOME, '.claude', 'pinboard.json')
 const SUMMARIES_DIR = path.join(process.env.HOME, '.claude', 'daily-summaries')
 const BRIEFINGS_DIR = path.join(process.env.HOME, '.claude', 'briefings')
 
-function getGiteaToken() {
+function getGitHubToken() {
   try {
-    return process.env.GITEA_TOKEN || readFileSync(
-      join(process.env.HOME, '.claude', '.gitea-token'), 'utf-8'
-    ).trim()
+    // Prefer env var, fall back to gh CLI auth
+    if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN
+    return execSync('gh auth token', { encoding: 'utf-8', timeout: 5000 }).trim()
   } catch {
     return ''
   }
 }
 
-function giteaIssuesPlugin() {
+function githubIssuesPlugin() {
   return {
-    name: 'gitea-issues-proxy',
+    name: 'github-issues-proxy',
     configureServer(server) {
       server.middlewares.use('/api/issues', async (req, res) => {
-        const token = getGiteaToken()
+        const token = getGitHubToken()
         const headers = {
-          'Content-Type': 'application/json',
-          ...(token ? { 'Authorization': `token ${token}` } : {}),
+          'Accept': 'application/vnd.github+json',
+          'User-Agent': 'wasteland-hq',
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
         }
 
         try {
           const allIssues = []
           for (const repo of REPO_NAMES) {
             try {
-              const url = `${GITEA_URL}/api/v1/repos/${GITEA_ORG}/${repo}/issues?state=open&type=issues&limit=50`
+              const url = `${GITHUB_URL}/repos/${GITHUB_ORG}/${repo}/issues?state=open&per_page=100`
               const response = await fetch(url, { headers })
               if (response.ok) {
                 const issues = await response.json()
                 allIssues.push(
-                  ...issues.map((issue) => ({
-                    id: issue.id,
-                    number: issue.number,
-                    title: issue.title,
-                    body: issue.body || '',
-                    state: issue.state,
-                    repo: repo,
-                    url: `${GITEA_URL}/${GITEA_ORG}/${repo}/issues/${issue.number}`,
-                    labels: (issue.labels || []).map((l) => ({
-                      name: l.name,
-                      color: l.color,
-                    })),
-                    assignees: (issue.assignees || []).map((a) => a.login),
-                    milestone: issue.milestone?.title || null,
-                    created_at: issue.created_at,
-                    updated_at: issue.updated_at,
-                    pull_request: issue.pull_request || null,
-                  }))
+                  // GitHub includes PRs in the issues endpoint; filter them out
+                  ...issues
+                    .filter((issue) => !issue.pull_request)
+                    .map((issue) => ({
+                      id: issue.id,
+                      number: issue.number,
+                      title: issue.title,
+                      body: issue.body || '',
+                      state: issue.state,
+                      repo: repo,
+                      url: issue.html_url,
+                      labels: (issue.labels || []).map((l) => ({
+                        name: l.name,
+                        color: l.color,
+                      })),
+                      assignees: (issue.assignees || []).map((a) => a.login),
+                      milestone: issue.milestone?.title || null,
+                      created_at: issue.created_at,
+                      updated_at: issue.updated_at,
+                    }))
                 )
               }
             } catch {
@@ -85,10 +84,11 @@ function issueStatsPlugin() {
     name: 'issue-stats-proxy',
     configureServer(server) {
       server.middlewares.use('/api/issue-stats', async (req, res) => {
-        const token = getGiteaToken()
+        const token = getGitHubToken()
         const headers = {
-          'Content-Type': 'application/json',
-          ...(token ? { 'Authorization': `token ${token}` } : {}),
+          'Accept': 'application/vnd.github+json',
+          'User-Agent': 'wasteland-hq',
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
         }
 
         try {
@@ -100,20 +100,24 @@ function issueStatsPlugin() {
 
           for (const repo of REPO_NAMES) {
             try {
-              // Fetch open issues
-              const openUrl = `${GITEA_URL}/api/v1/repos/${GITEA_ORG}/${repo}/issues?state=open&type=issues&limit=50`
+              // Fetch open issues (GitHub includes PRs — filter them out)
+              const openUrl = `${GITHUB_URL}/repos/${GITHUB_ORG}/${repo}/issues?state=open&per_page=100`
               const openRes = await fetch(openUrl, { headers })
               if (openRes.ok) {
                 const issues = await openRes.json()
-                openIssues.push(...issues.map(i => ({ ...i, repo })))
+                openIssues.push(
+                  ...issues.filter(i => !i.pull_request).map(i => ({ ...i, repo }))
+                )
               }
 
-              // Fetch recently closed issues (sorted by updated_at desc)
-              const closedUrl = `${GITEA_URL}/api/v1/repos/${GITEA_ORG}/${repo}/issues?state=closed&type=issues&limit=20&sort=updated&direction=desc`
+              // Fetch recently closed issues (sorted by updated desc)
+              const closedUrl = `${GITHUB_URL}/repos/${GITHUB_ORG}/${repo}/issues?state=closed&per_page=20&sort=updated&direction=desc`
               const closedRes = await fetch(closedUrl, { headers })
               if (closedRes.ok) {
                 const issues = await closedRes.json()
-                closedIssues.push(...issues.map(i => ({ ...i, repo })))
+                closedIssues.push(
+                  ...issues.filter(i => !i.pull_request).map(i => ({ ...i, repo }))
+                )
               }
             } catch {
               // Skip repos that fail
@@ -421,7 +425,7 @@ function parseBriefingToSummary(date, markdown) {
   let inIssues = false
   let currentRepo = null
   for (const line of lines) {
-    if (line.includes('Open Issues (Gitea)')) {
+    if (line.includes('Open Issues')) {
       inIssues = true
       continue
     }
@@ -468,7 +472,7 @@ function parseBriefingToSummary(date, markdown) {
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), hqApiPlugin(), giteaIssuesPlugin(), issueStatsPlugin(), dailyLogPlugin()],
+  plugins: [react(), hqApiPlugin(), githubIssuesPlugin(), issueStatsPlugin(), dailyLogPlugin()],
   server: {
     host: '0.0.0.0',
     hmr: {


### PR DESCRIPTION
## Summary
- Replace Gitea API with GitHub API across dashboard tooling
- `repos.js`: `GITEA_URL`/`GITEA_ORG` → `GITHUB_URL`/`GITHUB_ORG` (`severeon`)
- `vite.config.js`: `giteaIssuesPlugin` → `githubIssuesPlugin`, `issueStatsPlugin` updated — both now use GitHub REST API with `Bearer` token auth (from `GITHUB_TOKEN` env var or `gh auth token`)
- GitHub's `/issues` endpoint includes PRs, so both plugins now filter them out via `pull_request` key
- `TechTree.jsx`: UI text updated from "Gitea" to "GitHub"
- Fixed duplicate `fs`/`path` imports in vite.config.js

### Standalone files also updated (not in this repo):
- `~/.claude/lib/github-api.sh` — new `gh` CLI wrapper (`github_get`, `github_post`, `github_patch`, `github_create_issue`)
- `~/.claude/bin/hq-status-writer.py` — switched from `curl`+Gitea to `gh api`, repos now under `severeon/` org, PR filtering added

## Test plan
- [ ] Verify `gh auth token` returns a valid token
- [ ] Start wasteland-hq dev server and confirm `/api/issues` returns GitHub issues
- [ ] Confirm `/api/issue-stats` returns correct open/closed counts (no PRs counted)
- [ ] Verify TechTree loads issues and "Open in GitHub" links are correct
- [ ] Run `hq-status-writer.py` and confirm it produces valid `hq-status.json`
- [ ] Source `github-api.sh` and test `github_get "repos/severeon/wasteland-hq/issues?state=open"`

Closes tquick/wasteland-infra#24 (Gitea)

🤖 Generated with [Claude Code](https://claude.com/claude-code)